### PR TITLE
Fix icon paths for captured material pieces

### DIFF
--- a/frontend/src/components/global/CapturedMaterial.tsx
+++ b/frontend/src/components/global/CapturedMaterial.tsx
@@ -27,7 +27,7 @@ function CapturedMaterial({
 		const capturedMaterialElements = [];
 
 		const pieceTypeSingular = pluralToSingularPieceMap[pieceType];
-		const pieceFileName = `/${color}${capitaliseFirstLetter(
+		const pieceFileName = `/icons/chessPieces/regular/${color}${capitaliseFirstLetter(
 			pieceTypeSingular
 		)}.svg`;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the source location for chess piece images to use a new folder path, resulting in improved organization of image assets. This change does not affect gameplay or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->